### PR TITLE
Fix: Fixed Camera being sat short of new map size

### DIFF
--- a/GameEngine/src/main/java/dk/ee/zg/screens/GameScreen.java
+++ b/GameEngine/src/main/java/dk/ee/zg/screens/GameScreen.java
@@ -33,7 +33,8 @@ public class GameScreen implements Screen {
     private final WorldEntities worldEntities;
 
     /**
-     * Instance of {@link WorldObstacles} used for interacting with world obstacles.
+     * Instance of {@link WorldObstacles}
+     * used for interacting with world obstacles.
      */
     private final WorldObstacles worldObstacles;
 
@@ -80,7 +81,13 @@ public class GameScreen implements Screen {
      * The width of the map in pixels.
      * Should eventually be capable of calculating this based upon the map.
      */
-    private static final int MAP_WIDTH_PIXELS = 960;
+    private static final int MAP_WIDTH_PIXELS = 100 * 16;
+
+    /**
+     * The height of the map in pixels.
+     * Should eventually be capable of calculating this based upon the map.
+     */
+    private static final int MAP_HEIGHT_PIXELS = 150 * 16;
 
     /**
      * Constructor for GameScreen.
@@ -173,9 +180,9 @@ public class GameScreen implements Screen {
 
         // Top boundary
         if (camera.position.y
-                > MAP_WIDTH_PIXELS * UNIT_SCALE - effectiveViewportHeight) {
+                > MAP_HEIGHT_PIXELS * UNIT_SCALE - effectiveViewportHeight) {
             camera.position.y =
-                    MAP_WIDTH_PIXELS * UNIT_SCALE - effectiveViewportHeight;
+                    MAP_HEIGHT_PIXELS * UNIT_SCALE - effectiveViewportHeight;
         }
 
         camera.update();


### PR DESCRIPTION
This pull request includes changes to the `GameScreen` class in the `GameEngine` project to adjust the map dimensions and fix boundary checks. The most important changes include updating the map width and height constants and modifying the boundary check logic to use the new map height constant.

Improvements to map dimensions:

* [`GameEngine/src/main/java/dk/ee/zg/screens/GameScreen.java`](diffhunk://#diff-717fa3d9d6de1ebdb6ef40fb8d1750db3cdacc293ec48c7946a45eaa30ab9c5eL83-R89): Updated `MAP_WIDTH_PIXELS` to `100*16` and added `MAP_HEIGHT_PIXELS` set to `150*16`.

Boundary check adjustments:

* [`GameEngine/src/main/java/dk/ee/zg/screens/GameScreen.java`](diffhunk://#diff-717fa3d9d6de1ebdb6ef40fb8d1750db3cdacc293ec48c7946a45eaa30ab9c5eL176-R184): Modified the `checkBounds` method to use `MAP_HEIGHT_PIXELS` instead of `MAP_WIDTH_PIXELS` for the top boundary check.