### PR TITLE
fix: hitbox placement on sword

### DIFF
--- a/Map/src/main/java/dk/ee/zg/basemap/BaseMap.java
+++ b/Map/src/main/java/dk/ee/zg/basemap/BaseMap.java
@@ -59,7 +59,6 @@ public class BaseMap implements IMap {
         renderer.getBatch().begin();
         renderer.setView(GameData.getInstance().getCamera());
         for (int i = 0; i < objectsLayerIndex; i++) {
-            System.out.println(map.getLayers().get(i).getName());
             renderer.renderTileLayer(
                     (TiledMapTileLayer) map.getLayers().get(i));
         }
@@ -76,7 +75,6 @@ public class BaseMap implements IMap {
         renderer.getBatch().begin();
         renderer.setView(GameData.getInstance().getCamera());
         for (int i = objectsLayerIndex; i < map.getLayers().getCount(); i++) {
-            System.out.println("TOP ------" + map.getLayers().get(i).getName());
             renderer.renderTileLayer(
                     (TiledMapTileLayer) map.getLayers().get(i));
         }

--- a/Player/src/main/java/dk/ee/zg/player/PlayerControlSystem.java
+++ b/Player/src/main/java/dk/ee/zg/player/PlayerControlSystem.java
@@ -119,7 +119,18 @@ public class PlayerControlSystem implements IEntityProcessService {
 
         if (player.isPresent()) {
             move(player.get(), dirVec);
+
+            Weapon weapon = player.get().getWeapon();
+
+            //if move direction is not none, then set attack direction.
+            if (weapon != null && moveDirection != MoveDirection.NONE) {
+                weapon.setAttackDirection(
+                        AttackDirection.valueOf(moveDirection.name()));
+            }
         }
+
+
+
     }
 
     /**
@@ -133,21 +144,13 @@ public class PlayerControlSystem implements IEntityProcessService {
         if (player.isPresent()) {
 
             Weapon weapon = player.get().getWeapon();
-            //if move direction is not none, then set attack direction.
-            if (weapon != null && moveDirection != MoveDirection.NONE) {
-                weapon.setAttackDirection(
-                        AttackDirection.valueOf(moveDirection.name()));
-            }
 
             if (isAttacking && weapon != null) {
-                Vector2 center = new Vector2();
+                Vector2 center = player.get().getPosition();
                 Vector2 size = new Vector2();
-                player.get().getSprite().
-                        getBoundingRectangle().getCenter(center);
                 player.get().getSprite().getBoundingRectangle().getSize(size);
                 attackHitbox = weapon.attack(
                         center, size);
-
             } else if (!isAttacking) {
                 attackHitbox = null;
             }

--- a/Sword/src/main/java/dk/ee/zg/weapon/Sword.java
+++ b/Sword/src/main/java/dk/ee/zg/weapon/Sword.java
@@ -44,21 +44,21 @@ public class Sword extends Weapon {
             case LEFT -> {
                 height = 2;
                 attackOffsetX = -(playerSize.x / 2) - width - 0.25f;
-                attackOffsetY = -playerSize.y / 2 - (height - playerSize.y / 2);
+                attackOffsetY = -(height / 2);
             }
             case RIGHT -> {
                 height = 2;
                 attackOffsetX = (playerSize.x / 2) + 0.25f;
-                attackOffsetY = -playerSize.y / 2 - (height - playerSize.y / 2);
+                attackOffsetY = -(height / 2);
             }
             case UP -> {
                 width = 2;
-                attackOffsetY = playerSize.y / 2;
+                attackOffsetY = playerSize.y / 2 + 0.25f;
                 attackOffsetX = -(playerSize.x / 2) - width / 2;
             }
             case DOWN -> {
                 width = 2;
-                attackOffsetY = -playerSize.y / 2 - height;
+                attackOffsetY = -playerSize.y / 2 -  0.25f;
                 attackOffsetX = -(playerSize.x / 2) - width / 2;
             }
             default -> { }


### PR DESCRIPTION
This pull request includes several changes to the `BaseMap`, `PlayerControlSystem`, and `Sword` classes to improve the rendering process and weapon handling logic.

### Rendering improvements:

* [`BaseMap.java`](diffhunk://#diff-0d58553b1e1c500fa13f95d7a34ef856dd73275274fff7b37956324344d23d2dL62): Removed unnecessary debug print statements from the `renderBottom` and `renderTop` methods to clean up the console output. [[1]](diffhunk://#diff-0d58553b1e1c500fa13f95d7a34ef856dd73275274fff7b37956324344d23d2dL62) [[2]](diffhunk://#diff-0d58553b1e1c500fa13f95d7a34ef856dd73275274fff7b37956324344d23d2dL79)

### Weapon handling improvements:

* [`PlayerControlSystem.java`](diffhunk://#diff-2b07a7aeb6f8d2e75ac13abd6e053003af1a50c1a73d8b3db178e28ccc8ea72eR122-R135): Added logic to set the attack direction of the player's weapon based on the player's movement direction in the `process` method.
* [`PlayerControlSystem.java`](diffhunk://#diff-2b07a7aeb6f8d2e75ac13abd6e053003af1a50c1a73d8b3db178e28ccc8ea72eL136-L150): Refactored the `attack` method to use the player's position directly for calculating the attack hitbox center, removing redundant code.
* [`Sword.java`](diffhunk://#diff-da848578dc7351419bc8af6fac0899add6ae4493b7c0dbe15386f04fdfdb5f89L47-R61): Adjusted the attack offset calculations for different attack directions to ensure consistent hitbox positioning.